### PR TITLE
run_forecast sets to current timestamp rounded 15min if optional ts = None

### DIFF
--- a/quartz_solar_forecast/forecast.py
+++ b/quartz_solar_forecast/forecast.py
@@ -10,7 +10,7 @@ from quartz_solar_forecast.forecasts.v1 import forecast_v1
 
 
 
-def run_forecast(site: PVSite, ts: datetime | str, nwp_source: str = "icon") -> pd.DataFrame:
+def run_forecast(site: PVSite, ts: datetime | str = None, nwp_source: str = "icon") -> pd.DataFrame:
     """
     Run the forecast from NWP data
 
@@ -19,6 +19,10 @@ def run_forecast(site: PVSite, ts: datetime | str, nwp_source: str = "icon") -> 
     :param nwp_source: the nwp data source. Either "gfs" or "icon". Defaults to "icon"
     :return: The PV forecast of the site for time (ts) for 48 hours
     """
+
+    # set timestamp to now if not provided
+    if ts is None:
+        ts = pd.Timestamp.now().round("15min")
 
     if isinstance(ts, str):
         ts = datetime.fromisoformat(ts)

--- a/tests/test_forecast_no_ts.py
+++ b/tests/test_forecast_no_ts.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from quartz_solar_forecast.forecast import run_forecast
+from quartz_solar_forecast.pydantic_models import PVSite
+
+
+def test_run_forecast_no_ts():
+    # make input data
+    site = PVSite(latitude=51.75, longitude=-1.25, capacity_kwp=1.25)
+
+    current_ts = pd.Timestamp.now().round("15min")
+
+    # run model with no ts
+    predications_df = run_forecast(site=site)
+
+    # check current ts agrees with dataset
+    assert predications_df.index.min() == current_ts
+
+    print(predications_df)
+    print(f"Current time: {current_ts}")
+    print(f"Max: {predications_df['power_wh'].max()}")
+


### PR DESCRIPTION
# Pull Request

## Description

Solves #43 

Issue solution was essentially solved in pseudo code. 

If there is further motivation to convert to local timezone, a request can be made to include this in the code as part of this pull request (using module `timezonefinder`). Mostly would be relevant if sites were outside of UK and thus a local time discrepancy.

(This is my first ever contribution to a good first issue so happy to take any feedback!).

Fixes #

## How Has This Been Tested?

Using `examples/example.py` and removing the `ts` from [line 11](https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/blob/760bfd6295473054258fae39e9fbe86333ef2e33/examples/example.py#L11C17-L11C62)

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
