### PR TITLE
Fixed testset path in evaluation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 scripts/datapipes/test.nc
 scripts/datapipes/UK_PV_metadata.csv
 scripts/datapipes/nwp_data
+quartz_solar_forecast/data

--- a/quartz_solar_forecast/evaluation.py
+++ b/quartz_solar_forecast/evaluation.py
@@ -33,7 +33,7 @@ except:
     )
 
 
-def run_eval(testset_path: str = "quartz_solar_forecast/dataset/testset.csv"):
+def run_eval(testset_path: str = "dataset/testset.csv"):
 
     # load testset from csv
     testset = pd.read_csv(testset_path)


### PR DESCRIPTION
# Pull Request

## Description
Fixed the path in function `run_eval` in `evaluation.py` however running [scripts/run_evaluation.py](https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/blob/main/scripts/run_evaluation.py) is getting it from `quartz_solar_forecast package` and locally it is giving me the same error. 

<img width="1301" alt="Screenshot 2024-03-09 at 4 19 13 PM" src="https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/assets/47316899/e910d2d3-1c6b-46ff-bee2-8783cb199042">


By fixing it in [evaluation.py](https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/blob/main/quartz_solar_forecast/evaluation.py), I was able to run `run_eval()` in this file only. Still unable to run [scripts/run_evaluation.py](https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/blob/main/scripts/run_evaluation.py)

Fixes #78 


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
