### PR TITLE
bug in forecast.run_forecast: 'nwp_source' was not respected 

### DIFF
--- a/quartz_solar_forecast/forecast.py
+++ b/quartz_solar_forecast/forecast.py
@@ -25,8 +25,8 @@ def run_forecast(site: PVSite, ts: datetime | str = None, nwp_source: str = "ico
     if isinstance(ts, str):
         ts = datetime.fromisoformat(ts)
 
-    # make pv and nwp data from GFS
-    nwp_xr = get_nwp(site=site, ts=ts)
+    # make pv and nwp data from nwp_source
+    nwp_xr = get_nwp(site=site, ts=ts, nwp_source=nwp_source)
     pv_xr = make_pv_data(site=site, ts=ts)
 
     # load and run models


### PR DESCRIPTION
# Bug in forecast.run_forecast: 'nwp_source' was not respected when loading the NWP data. 

## Description
Because icon is default, it failed with gfs. 

To reproduce the error, the notebook can be executed in the example folder and the following code can be used for the prediction:
`predictions_df = run_forecast(site=site, ts='2023-10-15', nwp_source="gfs")`
