### PR TITLE
bug in forecast.run_forecast: 'nwp_source' was not respected  (#85)

### DIFF
--- a/quartz_solar_forecast/forecast.py
+++ b/quartz_solar_forecast/forecast.py
@@ -25,8 +25,8 @@ def run_forecast(site: PVSite, ts: datetime | str = None, nwp_source: str = "ico
     if isinstance(ts, str):
         ts = datetime.fromisoformat(ts)
 
-    # make pv and nwp data from GFS
-    nwp_xr = get_nwp(site=site, ts=ts)
+    # make pv and nwp data from nwp_source
+    nwp_xr = get_nwp(site=site, ts=ts, nwp_source=nwp_source)
     pv_xr = make_pv_data(site=site, ts=ts)
 
     # load and run models

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -6,9 +6,14 @@ def test_run_forecast():
     # make input data
     site = PVSite(latitude=51.75, longitude=-1.25, capacity_kwp=1.25)
 
-    # run model
-    predications_df = run_forecast(site=site, ts='2023-10-30')
+    # run model with icon and gfs nwp
+    predications_df_gfs = run_forecast(site=site, ts='2023-10-30', nwp_source="gfs")
+    predications_df_icon = run_forecast(site=site, ts='2023-10-30', nwp_source="icon")
 
-    print(predications_df)
-    print(f"Max: {predications_df['power_wh'].max()}")
+    print("\nPrediction based on GFS NWP\n")
+    print(predications_df_gfs)
+    print(f"Max: {predications_df_gfs['power_wh'].max()}")
 
+    print("\nPrediction based on ICON NWP\n")
+    print(predications_df_icon)
+    print(f"Max: {predications_df_icon['power_wh'].max()}")


### PR DESCRIPTION
* bug in forecast.run_forecast: 'nwp_source' was not respected when loading the nwp data

* adjustment of the test for run_forecast. Test for ICON and GFS NWP.

---------

# Pull Request

## Description

Fix bug for gfs + test

Fixes #

## How Has This Been Tested?

CI tests + new trest

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
