### PR TITLE
updated enphase api to v4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 ENPHASE_SYSTEM_ID = 'user_enphase_system_id'
 ENPHASE_CLIENT_ID = 'user_enphase_client_id'
 ENPHASE_CLIENT_SECRET = 'user_enphase_client_secret'
-ENPHASE_API_KEY = 'user_enphase_api-key'
+ENPHASE_API_KEY = 'user_enphase_api_key'
 
 # This section is for OpenMeteo setup
 

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ ENPHASE_SYSTEM_ID = 'user_enphase_system_id'
 ENPHASE_CLIENT_ID = 'user_enphase_client_id'
 ENPHASE_CLIENT_SECRET = 'user_enphase_client_secret'
 ENPHASE_API_KEY = 'user_enphase_api_key'
+# Replace ENPHASE_CLIENT_ID below with the actual client id 
+AUTHORIZATION_URL = 'https://api.enphaseenergy.com/oauth/authorize?response_type=code&client_id=ENPHASE_CLIENT_ID'
 
 # This section is for OpenMeteo setup
 

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # User needs to add their Enphase API details
 ENPHASE_API_KEY = 'user_enphase_api_key'
-ENPHASE_USER_ID = 'user_enphase_user_id'
+ENPHASE_SYSTEM_ID = 'user_enphase_system_id'
+ENPHASE_ACCESS_TOKEN = 'user_enphase_access_token'
 
 # This section is for OpenMeteo setup
 

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # User needs to add their Enphase API details
-ENPHASE_API_KEY = 'user_enphase_api_key'
+
 ENPHASE_SYSTEM_ID = 'user_enphase_system_id'
-ENPHASE_ACCESS_TOKEN = 'user_enphase_access_token'
+ENPHASE_CLIENT_ID = 'user_enphase_client_id'
+ENPHASE_CLIENT_SECRET = 'user_enphase_client_secret'
+ENPHASE_API_KEY = 'user_enphase_api-key'
 
 # This section is for OpenMeteo setup
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ scripts/datapipes/UK_PV_metadata.csv
 scripts/datapipes/nwp_data
 quartz_solar_forecast/data
 .env
+venv

--- a/quartz_solar_forecast/data.py
+++ b/quartz_solar_forecast/data.py
@@ -16,9 +16,7 @@ ssl._create_default_https_context = ssl._create_unverified_context
 
 from dotenv import load_dotenv
 
-ENPHASE_API_KEY = os.getenv('ENPHASE_API_KEY')
 ENPHASE_SYSTEM_ID = os.getenv('ENPHASE_SYSTEM_ID')
-ENPHASE_ACCESS_TOKEN = os.getenv('ENPHASE_ACCESS_TOKEN')
 
 def get_nwp(site: PVSite, ts: datetime, nwp_source: str = "icon") -> xr.Dataset:
     """
@@ -133,7 +131,7 @@ def make_pv_data(site: PVSite, ts: pd.Timestamp) -> xr.Dataset:
 
     if use_enphase_data:
         # Fetch live Enphase data and store it in live_generation_wh
-        live_generation_wh = get_enphase_data(ENPHASE_SYSTEM_ID, ENPHASE_API_KEY, ENPHASE_ACCESS_TOKEN)
+        live_generation_wh = get_enphase_data(ENPHASE_SYSTEM_ID)
     else:
         live_generation_wh = np.nan  # Default value if not using live Enphase data
 

--- a/quartz_solar_forecast/data.py
+++ b/quartz_solar_forecast/data.py
@@ -2,7 +2,7 @@
 import json
 import ssl
 from datetime import datetime
-import os  # Add import for os module
+import os  
 
 import numpy as np
 import pandas as pd
@@ -10,14 +10,12 @@ import requests
 import xarray as xr
 
 from quartz_solar_forecast.pydantic_models import PVSite
-from quartz_solar_forecast.inverters.enphase import get_enphase_data # Added import for get_enphase_data from /inverters/enphase.py
+from quartz_solar_forecast.inverters.enphase import get_enphase_data
 
 ssl._create_default_https_context = ssl._create_unverified_context
 
-# Load environment variables from .env file
 from dotenv import load_dotenv
 
-# Assigning secrets from the .env file
 ENPHASE_API_KEY = os.getenv('ENPHASE_API_KEY')
 ENPHASE_SYSTEM_ID = os.getenv('ENPHASE_SYSTEM_ID')
 ENPHASE_ACCESS_TOKEN = os.getenv('ENPHASE_ACCESS_TOKEN')
@@ -123,13 +121,16 @@ def format_nwp_data(df: pd.DataFrame, nwp_source:str, site: PVSite):
 def make_pv_data(site: PVSite, ts: pd.Timestamp) -> xr.Dataset:
     """
     Make PV data by combining Enphase live data and fake PV data
+
     Later we could add PV history here
+
     :param site: the PV site
     :param ts: the timestamp of the site
     :return: The combined PV dataset in xarray form
     """
     # Check if the site has an inverter and use_enphase_data flag accordingly
     use_enphase_data = site.is_inverter
+
     if use_enphase_data:
         # Fetch live Enphase data and store it in live_generation_wh
         live_generation_wh = get_enphase_data(ENPHASE_SYSTEM_ID, ENPHASE_API_KEY, ENPHASE_ACCESS_TOKEN)
@@ -142,6 +143,7 @@ def make_pv_data(site: PVSite, ts: pd.Timestamp) -> xr.Dataset:
     lat = [site.latitude]
     timestamp = [ts]
     pv_id = [1]
+
     da = xr.DataArray(
         data=generation_wh,
         dims=["pv_id", "timestamp"],
@@ -156,4 +158,5 @@ def make_pv_data(site: PVSite, ts: pd.Timestamp) -> xr.Dataset:
         ),
     )
     da = da.to_dataset(name="generation_wh")
+
     return da

--- a/quartz_solar_forecast/data.py
+++ b/quartz_solar_forecast/data.py
@@ -146,13 +146,13 @@ def make_pv_data(site: PVSite, ts: pd.Timestamp) -> xr.Dataset:
         data=generation_wh,
         dims=["pv_id", "timestamp"],
         coords=dict(
-            longitude=("pv_id", lon),
-            latitude=("pv_id", lat),
+            longitude=(["pv_id"], lon),
+            latitude=(["pv_id"], lat),
             timestamp=timestamp,
             pv_id=pv_id,
-            kwp=("pv_id", [site.capacity_kwp]),
-            tilt=("pv_id", [site.tilt]),
-            orientation=("pv_id", [site.orientation]),
+            kwp=(["pv_id"], [site.capacity_kwp]),
+            tilt=(["pv_id"], [site.tilt]),
+            orientation=(["pv_id"], [site.orientation]),
         ),
     )
     da = da.to_dataset(name="generation_wh")

--- a/quartz_solar_forecast/inverters/enphase.py
+++ b/quartz_solar_forecast/inverters/enphase.py
@@ -3,6 +3,7 @@ import requests
 def get_enphase_data(enphase_system_id: str, enphase_api_key: str, enphase_access_token: str) -> float:
     """
     Get live PV generation data from Enphase API v4
+
     :param enphase_system_id: System ID for Enphase API
     :param enphase_api_key: API Key for Enphase API
     :param enphase_access_token: Access token for Enphase API
@@ -13,8 +14,11 @@ def get_enphase_data(enphase_system_id: str, enphase_api_key: str, enphase_acces
         'Authorization': f'Bearer {enphase_access_token}',
         'key': enphase_api_key
     }
+
     response = requests.get(url, headers=headers)
     data = response.json()
+
     # Extracting live generation data assuming it's in Watt-hours
     live_generation_wh = data['current_power']['power']
+    
     return live_generation_wh

--- a/quartz_solar_forecast/inverters/enphase.py
+++ b/quartz_solar_forecast/inverters/enphase.py
@@ -1,20 +1,20 @@
 import requests
 
-def get_enphase_data(enphase_user_id: str, enphase_api_key: str) -> float:
+def get_enphase_data(enphase_system_id: str, enphase_api_key: str, enphase_access_token: str) -> float:
     """
-    Get live PV generation data from Enphase API
-
-    :param enphase_user_id: User ID for Enphase API
+    Get live PV generation data from Enphase API v4
+    :param enphase_system_id: System ID for Enphase API
     :param enphase_api_key: API Key for Enphase API
+    :param enphase_access_token: Access token for Enphase API
     :return: Live PV generation in Watt-hours, assumes to be a floating-point number
     """
-    url = f'https://api.enphaseenergy.com/api/v2/systems/{enphase_user_id}/summary'
-    headers = {'Authorization': f'Bearer {enphase_api_key}'}
-
+    url = f'https://api.enphaseenergy.com/api/v4/{enphase_system_id}/summary'
+    headers = {
+        'Authorization': f'Bearer {enphase_access_token}',
+        'key': enphase_api_key
+    }
     response = requests.get(url, headers=headers)
     data = response.json()
-
     # Extracting live generation data assuming it's in Watt-hours
-    live_generation_wh = data['current_power']['power']
-
+    live_generation_wh = data['production']['total_energy']
     return live_generation_wh

--- a/quartz_solar_forecast/inverters/enphase.py
+++ b/quartz_solar_forecast/inverters/enphase.py
@@ -16,5 +16,5 @@ def get_enphase_data(enphase_system_id: str, enphase_api_key: str, enphase_acces
     response = requests.get(url, headers=headers)
     data = response.json()
     # Extracting live generation data assuming it's in Watt-hours
-    live_generation_wh = data['production']['total_energy']
+    live_generation_wh = data['current_power']['power']
     return live_generation_wh

--- a/quartz_solar_forecast/inverters/enphase.py
+++ b/quartz_solar_forecast/inverters/enphase.py
@@ -25,8 +25,6 @@ def get_enphase_access_token():
     response.raise_for_status()
     return response.json()["access_token"]
 
-import requests
-
 def get_enphase_data(enphase_system_id: str) -> float:
     """
     Get live PV generation data from Enphase API v4

--- a/quartz_solar_forecast/inverters/enphase.py
+++ b/quartz_solar_forecast/inverters/enphase.py
@@ -1,18 +1,43 @@
 import requests
+import os
 
-def get_enphase_data(enphase_system_id: str, enphase_api_key: str, enphase_access_token: str) -> float:
+from dotenv import load_dotenv
+
+ENPHASE_CLIENT_ID = os.getenv('ENPHASE_CLIENT_ID')
+ENPHASE_CLIENT_SECRET = os.getenv('ENPHASE_CLIENT_SECRET')
+ENPHASE_API_KEY = os.getenv('ENPHASE_API_KEY')
+
+def get_enphase_access_token():
+    """
+    Obtain an access token for the Enphase API using the Client Credentials Grant flow.
+    """
+    url = "https://api.enphaseenergy.com/oauth/token"
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Authorization": f"Basic {(ENPHASE_CLIENT_ID + ':' + ENPHASE_CLIENT_SECRET).encode().decode('utf-8')}",
+    }
+    data = {
+        "grant_type": "client_credentials",
+        "scope": "read"
+    }
+
+    response = requests.post(url, headers=headers, data=data)
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+import requests
+
+def get_enphase_data(enphase_system_id: str) -> float:
     """
     Get live PV generation data from Enphase API v4
 
     :param enphase_system_id: System ID for Enphase API
-    :param enphase_api_key: API Key for Enphase API
-    :param enphase_access_token: Access token for Enphase API
     :return: Live PV generation in Watt-hours, assumes to be a floating-point number
     """
     url = f'https://api.enphaseenergy.com/api/v4/{enphase_system_id}/summary'
     headers = {
-        'Authorization': f'Bearer {enphase_access_token}',
-        'key': enphase_api_key
+        'Authorization': f'Bearer {get_enphase_access_token()}',
+        'key': ENPHASE_API_KEY
     }
 
     response = requests.get(url, headers=headers)


### PR DESCRIPTION
# Pull Request

## Description
This links with #36 
Building on what markus said [here](https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/issues/59#issuecomment-2052185061), I have updated the older version of enphase api v2 which is going to be deprecated in 30th april 2024, to the latest v4 api. I have made corresponding changes in the docs in the code and added an OAuth 2.0 access token as Authorization header using the Bearer scheme with the application api key in the header as mentioned in the latest [docs](https://developer-v4.enphase.com/docs.html)

## What I did
Obtained the required credentials from the Enphase developer portal:
AUTHORIZATION_URL, ENPHASE_API_KEY, ENPHASE_CLIENT_ID, and ENPHASE_CLIENT_SECRET and updated the .env.example file

## Next steps
#107 


## Additions to enhance usage from my last merge on this (#66)
Added a function get_enphase_access_token to dynamically generate an access token based on the ENPHASE_CLIENT_ID and ENPHASE_CLIENT_SECRET, which is then used by the get_enphase_data function using the Bearer-Token authentication.
I have integrated a full fledged oauth2.0 authentication as was required for this version of the API as per the docs.

## How Has This Been Tested?

I have created an account on the latest [developer-v4 enphase](https://developer-v4.enphase.com/). I have also managed to create an application to get the Enphase credentials(apart from the system_id), which is why I am using the default redirect URI given in the docs. 
If anyone with actual access to a system can test this code, do let me know the results

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
