### PR TITLE
change from mean to hourly average #112

### DIFF
--- a/quartz_solar_forecast/eval/nwp.py
+++ b/quartz_solar_forecast/eval/nwp.py
@@ -151,6 +151,13 @@ def get_nwp_for_one_timestamp_one_location(
         }
     )
 
+    # change dswrf and dlwrf to hourly mean, rather than forecast mean
+    df["dswrf_cumsum"] = df["dswrf"]*range(1, len(df)+1)
+    df["dlwrf"][1:] = df["dswrf_cumsum"].diff()[1:]
+    df["dlwrf_cumsum"] = df["dlwrf"] * range(1, len(df) + 1)
+    df["dlwrf"][1:] = df["dlwrf_cumsum"].diff()[1:]
+    df = df.drop(columns=["dswrf_cumsum", "dlwrf_cumsum"])
+
     # add visbility for the moment
     # TODO
     df["vis"] = 10000


### PR DESCRIPTION
# Pull Request

## Description

add change for NWP from ICON. 
The irradience variables are its a continuous mean from a forecast, compared to a hourly average

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
