### PR TITLE
Add UKMO model for inference as a option

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -9,7 +9,7 @@ def main():
     
     ts = datetime.today() - timedelta(weeks=1)
 
-    # User has three options for the 'nwp_source': 'icon', 'gfs', or 'ukmo_seamless'.
+    # User has three options for the 'nwp_source': 'icon', 'gfs', or 'ukmo'.
     predictions_df = run_forecast(site=site, ts=ts, nwp_source="icon")
 
     print(predictions_df)

--- a/examples/example.py
+++ b/examples/example.py
@@ -8,6 +8,8 @@ def main():
     site = PVSite(latitude=51.75, longitude=-1.25, capacity_kwp=1.25)
     
     ts = datetime.today() - timedelta(weeks=1)
+
+    # User has three options for the 'nwp_source': 'icon', 'gfs', or 'ukmo_seamless'.
     predictions_df = run_forecast(site=site, ts=ts, nwp_source="icon")
 
     print(predictions_df)

--- a/quartz_solar_forecast/data.py
+++ b/quartz_solar_forecast/data.py
@@ -21,7 +21,7 @@ def get_nwp(site: PVSite, ts: datetime, nwp_source: str = "icon") -> xr.Dataset:
 
     :param site: the PV site
     :param ts: the timestamp for when you want the forecast for
-    :param nwp_source: the nwp data source. Either "gfs" or "icon". Defaults to "icon"
+    :param nwp_source: the nwp data source. Either "gfs", "icon" or "ukmo". Defaults to "icon"
     :return: nwp forecast in xarray
     """
 
@@ -62,10 +62,10 @@ def get_nwp(site: PVSite, ts: datetime, nwp_source: str = "icon") -> xr.Dataset:
         elif nwp_source == "gfs":
             url_nwp_source = "gfs"
             url = f"https://api.open-meteo.com/v1/{url_nwp_source}"
-        elif nwp_source == "ukmo_seamless":
+        elif nwp_source == "ukmo":
             url = "https://api.open-meteo.com/v1/forecast"
         else:
-            raise Exception(f'Source ({nwp_source}) must be either "icon", "gfs", or "ukmo_seamless"')
+            raise Exception(f'Source ({nwp_source}) must be either "icon", "gfs", or "ukmo"')
 
     params = {
         "latitude": site.latitude,
@@ -75,8 +75,8 @@ def get_nwp(site: PVSite, ts: datetime, nwp_source: str = "icon") -> xr.Dataset:
         "hourly": variables
     }
 
-    # Add the "models" parameter if using "ukmo_seamless"
-    if nwp_source == "ukmo_seamless":
+    # Add the "models" parameter if using "ukmo"
+    if nwp_source == "ukmo":
         params["models"] = "ukmo_seamless"
 
     # Make API call to URL

--- a/quartz_solar_forecast/data.py
+++ b/quartz_solar_forecast/data.py
@@ -55,25 +55,31 @@ def get_nwp(site: PVSite, ts: datetime, nwp_source: str = "icon") -> xr.Dataset:
         url = "https://archive-api.open-meteo.com/v1/archive"
 
     else:
-
-        # Getting NWP from open meteo weather forecast API by ICON or GFS model within the last 3 months
-        url_nwp_source = None
+        # Getting NWP from open meteo weather forecast API by ICON, GFS, or UKMO within the last 3 months
         if nwp_source == "icon":
             url_nwp_source = "dwd-icon"
+            url = f"https://api.open-meteo.com/v1/{url_nwp_source}"
         elif nwp_source == "gfs":
             url_nwp_source = "gfs"
+            url = f"https://api.open-meteo.com/v1/{url_nwp_source}"
+        elif nwp_source == "ukmo_seamless":
+            url = "https://api.open-meteo.com/v1/forecast"
         else:
-            raise Exception(f'Source ({nwp_source}) must be either "icon" or "gfs"')
-
-        url = f"https://api.open-meteo.com/v1/{url_nwp_source}"
+            raise Exception(f'Source ({nwp_source}) must be either "icon", "gfs", or "ukmo_seamless"')
 
     params = {
-    	"latitude": site.latitude,
-    	"longitude": site.longitude,
-    	"start_date": f"{start}",
-    	"end_date": f"{end}",
-    	"hourly": variables
+        "latitude": site.latitude,
+        "longitude": site.longitude,
+        "start_date": f"{start}",
+        "end_date": f"{end}",
+        "hourly": variables
     }
+
+    # Add the "models" parameter if using "ukmo_seamless"
+    if nwp_source == "ukmo_seamless":
+        params["models"] = "ukmo_seamless"
+
+    # Make API call to URL
     response = openmeteo.weather_api(url, params=params)
     hourly = response[0].Hourly()
 

--- a/quartz_solar_forecast/forecast.py
+++ b/quartz_solar_forecast/forecast.py
@@ -16,7 +16,7 @@ def predict_ocf(
     :param site: the PV site
     :param model: the model to use for prediction
     :param ts: the timestamp of the site. If None, defaults to the current timestamp rounded down to 15 minutes.
-    :param nwp_source: the nwp data source. Either "gfs" or "icon". Defaults to "icon" 
+    :param nwp_source: the nwp data source. Either "gfs", "icon" or "ukmo". Defaults to "icon" 
     :return: The PV forecast of the site for time (ts) for 48 hours
     """
     if ts is None:
@@ -103,7 +103,7 @@ def run_forecast(
     :param model: the model to use for prediction, choose between "ocf" and "tryolabs",
                     by default "ocf" is used
     :param ts: the timestamp of the site. If None, defaults to the current timestamp rounded down to 15 minutes.
-    :param nwp_source: the nwp data source. Either "gfs" or "icon". Defaults to "icon" 
+    :param nwp_source: the nwp data source. Either "gfs", "icon" or "ukmo". Defaults to "icon" 
                        (only relevant if model=="gb")
     :return: The PV forecast of the site for time (ts) for 48 hours
     """

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -10,6 +10,7 @@ def test_run_forecast():
     # run model with icon and gfs nwp
     predications_df_gfs = run_forecast(site=site, model="gb", ts=ts, nwp_source="gfs")
     predications_df_icon = run_forecast(site=site, model="gb", ts=ts, nwp_source="icon")
+    predications_df_ukmo = run_forecast(site=site, model="gb", ts=ts, nwp_source="ukmo_seamless")
     predications_df_xgb = run_forecast(site=site, ts=ts)
 
     print("\n Prediction based on GFS NWP\n")
@@ -19,6 +20,10 @@ def test_run_forecast():
     print("\n Prediction based on ICON NWP\n")
     print(predications_df_icon)
     print(f" Max: {predications_df_icon['power_kw'].max()}")
+
+    print("\n Prediction based on UKMO NWP\n")
+    print(predications_df_ukmo)
+    print(f" Max: {predications_df_ukmo['power_kw'].max()}")
 
     print("\n Prediction based on XGB\n")
     print(predications_df_xgb)
@@ -34,6 +39,7 @@ def test_run_forecast_historical():
     # run model with icon and gfs nwp
     predications_df_gfs = run_forecast(site=site, ts=ts, model="gb", nwp_source="gfs")
     predications_df_icon = run_forecast(site=site, ts=ts, model="gb", nwp_source="icon")
+    predications_df_ukmo = run_forecast(site=site, ts=ts, model="gb", nwp_source="ukmo_seamless")
     predications_df_xgb = run_forecast(site=site, ts=ts, model="xgb")
 
     print("\nPrediction for a date more than 180 days in the past")
@@ -45,6 +51,10 @@ def test_run_forecast_historical():
     print("\n Prediction based on ICON NWP\n")
     print(predications_df_icon)
     print(f" Max: {predications_df_icon['power_kw'].max()}")
+
+    print("\n Prediction based on UKMO NWP\n")
+    print(predications_df_ukmo)
+    print(f" Max: {predications_df_ukmo['power_kw'].max()}")
     
     print("\n Prediction based on XGB\n")
     print(predications_df_xgb)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -7,7 +7,7 @@ def test_run_forecast():
     site = PVSite(latitude=51.75, longitude=-1.25, capacity_kwp=1.25)
     ts = datetime.today() - timedelta(weeks=2)
 
-    # run model with icon and gfs nwp
+    # run model with icon, gfs and ukmo nwp
     predications_df_gfs = run_forecast(site=site, model="gb", ts=ts, nwp_source="gfs")
     predications_df_icon = run_forecast(site=site, model="gb", ts=ts, nwp_source="icon")
     predications_df_ukmo = run_forecast(site=site, model="gb", ts=ts, nwp_source="ukmo_seamless")
@@ -36,7 +36,7 @@ def test_run_forecast_historical():
     site = PVSite(latitude=51.75, longitude=-1.25, capacity_kwp=1.25)
     ts = datetime.today() - timedelta(days=200)
 
-    # run model with icon and gfs nwp
+    # run model with icon, gfs and ukmo nwp
     predications_df_gfs = run_forecast(site=site, ts=ts, model="gb", nwp_source="gfs")
     predications_df_icon = run_forecast(site=site, ts=ts, model="gb", nwp_source="icon")
     predications_df_ukmo = run_forecast(site=site, ts=ts, model="gb", nwp_source="ukmo_seamless")

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -10,7 +10,7 @@ def test_run_forecast():
     # run model with icon, gfs and ukmo nwp
     predications_df_gfs = run_forecast(site=site, model="gb", ts=ts, nwp_source="gfs")
     predications_df_icon = run_forecast(site=site, model="gb", ts=ts, nwp_source="icon")
-    predications_df_ukmo = run_forecast(site=site, model="gb", ts=ts, nwp_source="ukmo_seamless")
+    predications_df_ukmo = run_forecast(site=site, model="gb", ts=ts, nwp_source="ukmo")
     predications_df_xgb = run_forecast(site=site, ts=ts)
 
     print("\n Prediction based on GFS NWP\n")
@@ -39,7 +39,7 @@ def test_run_forecast_historical():
     # run model with icon, gfs and ukmo nwp
     predications_df_gfs = run_forecast(site=site, ts=ts, model="gb", nwp_source="gfs")
     predications_df_icon = run_forecast(site=site, ts=ts, model="gb", nwp_source="icon")
-    predications_df_ukmo = run_forecast(site=site, ts=ts, model="gb", nwp_source="ukmo_seamless")
+    predications_df_ukmo = run_forecast(site=site, ts=ts, model="gb", nwp_source="ukmo")
     predications_df_xgb = run_forecast(site=site, ts=ts, model="xgb")
 
     print("\nPrediction for a date more than 180 days in the past")


### PR DESCRIPTION
# Pull Request

## Description
This PR solves https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/issues/179

I have added [UKMO](https://open-meteo.com/en/docs/ukmo-api#hourly=)  model for inference as an option in the [get_nwp()](https://github.com/openclimatefix/Open-Source-Quartz-Solar-Forecast/blob/0208f57ba30d46ca033e645a2df292b8560b6928/quartz_solar_forecast/data.py#L18)   


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
