### PR TITLE
Fix: Handle missing generation_power values during evaluation (#110)

### DIFF
--- a/quartz_solar_forecast/evaluation.py
+++ b/quartz_solar_forecast/evaluation.py
@@ -44,6 +44,7 @@ def run_eval(testset_path: str = "dataset/testset.csv"):
     # Split data into PV inputs and ground truth. (Zak)
     ground_truth_df = get_pv_truth(testset)
 
+
     # Collect NWP data from Hugging Face, ICON. (Peter)
     nwp_df = get_nwp(pv_metadata)
 
@@ -53,8 +54,11 @@ def run_eval(testset_path: str = "dataset/testset.csv"):
     # Combine the forecast results with the ground truth (ts, id, horizon (in hours), pred, truth, diff)
     results_df = combine_forecast_ground_truth(predictions_df, ground_truth_df)
 
+    # Drop rows where generation_power is missing
+    results_df = results_df.dropna(subset=["generation_power"])
+
     # Save file
-    results_df.to_csv("results.csv")
+    results_df.to_csv("results.csv", index=False)
 
     # Calculate and print metrics: MAE
     metrics(results_df, pv_metadata, include_night=True)


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes the issue raised in [#110](https://github.com/openclimatefix/quartz-solar-forecast/issues/110), where missing real generation_power values in evaluation caused errors and incomplete results.

## Changes
- Added a safeguard to drop rows where `generation_power` is missing during evaluation.
- Ensures that evaluation completes without crashing even when some historical generation data is unavailable.
- Followed the discussion on bias concerns, but since missing values are likely random, dropping missing rows is acceptable.

## Why this fix?
- Keeps evaluation simple and clean.
- Prevents evaluation crashes caused by missing real generation labels.
- Matches the consensus reached by project maintainers in the issue discussion.

## How I tested
- Rebuilt the `testset.csv`.
- Ran `python scripts/run_evaluation.py`.
- Confirmed that evaluation runs successfully without errors related to missing generation_power
