### PR TITLE
Mock calls to Open-Meteo API

### DIFF
--- a/quartz_solar_forecast/forecasts/v2.py
+++ b/quartz_solar_forecast/forecasts/v2.py
@@ -164,11 +164,30 @@ class TryolabsSolarPowerPredictor:
         start_date_datetime = datetime.datetime.strptime(start_date, "%Y-%m-%d")
         end_date_datetime = start_date_datetime + datetime.timedelta(days=2)
         end_date = end_date_datetime.strftime("%Y-%m-%d")
+        variables = [
+            "temperature_2m",
+            "relative_humidity_2m",
+            "dew_point_2m",
+            "precipitation",
+            "surface_pressure",
+            "cloud_cover",
+            "cloud_cover_low",
+            "cloud_cover_mid",
+            "cloud_cover_high",
+            "wind_speed_10m",
+            "wind_direction_10m",
+            "is_day",
+            "shortwave_radiation",
+            "direct_radiation",
+            "diffuse_radiation",
+            "direct_normal_irradiance",
+            "terrestrial_radiation",
+        ]
 
         weather_service = WeatherService()
 
         weather_data = weather_service.get_hourly_weather(
-            latitude, longitude, start_date, end_date
+            latitude, longitude, start_date, end_date, variables
         )
 
         PANEL_COLUMNS = [

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import pytest
+
+from quartz_solar_forecast.weather.open_meteo import WeatherService
+
+
+# Fixture for getting hourly data from Open-Meteo API
+@pytest.fixture
+def mock_weather_api(monkeypatch):
+    # Monkeypatch get_hourly_weather method:
+    # behavior same to original method, returns dummy weather data (zeroes)
+    def mock_get_hourly_weather(self, latitude, longitude, start_date, end_date, variables=[], api_type="forecast", model=None):
+        mock_hourly_date = pd.date_range(
+        	start = pd.to_datetime(start_date, format="%Y-%m-%d", utc = False),
+        	end = pd.to_datetime(end_date, format="%Y-%m-%d", utc = False) + pd.Timedelta(days=1),
+        	freq = pd.Timedelta(hours=1),
+        	inclusive = "left"
+        )
+        mock_weather_df = pd.DataFrame({ "date": mock_hourly_date })
+        # Fill with zeroes (fake weather data)
+        for v in variables:
+            mock_weather_df[v] = 0.0
+        return mock_weather_df
+
+    monkeypatch.setattr(WeatherService, "get_hourly_weather", mock_get_hourly_weather)

--- a/tests/unit/test_forecast_no_ts.py
+++ b/tests/unit/test_forecast_no_ts.py
@@ -1,9 +1,10 @@
 import pandas as pd
+
 from quartz_solar_forecast.forecast import run_forecast
 from quartz_solar_forecast.pydantic_models import PVSite
+from tests.unit.mocks import mock_weather_api
 
-
-def test_run_forecast_no_ts():
+def test_run_forecast_no_ts(mock_weather_api):
     # make input data
     site = PVSite(latitude=51.75, longitude=-1.25, capacity_kwp=1.25)
 

--- a/tests/unit/test_generate_forecast.py
+++ b/tests/unit/test_generate_forecast.py
@@ -4,8 +4,9 @@ from datetime import datetime, timedelta
 import quartz_solar_forecast.forecast as forecast
 from quartz_solar_forecast.utils.forecast_csv import write_out_forecasts
 from quartz_solar_forecast.pydantic_models import PVSite
+from tests.unit.mocks import mock_weather_api
 
-def test_generate_forecast(monkeypatch):
+def test_generate_forecast(monkeypatch, mock_weather_api):
     site_name = "TestCase"
     latitude = 51.75
     longitude = -1.25


### PR DESCRIPTION
# Pull Request

## Description

While executing unit tests in scope of github testing workflow, some requests to Open-Meteo API take a lot of time, and then fall with timeout (probably due to large timespans or authorization issues). It is considered to be not a good practice at all - to do network requests inside of unit tests. In scope of this fix, calls to Open-Meteo API are mocked with a fixture, which leads to smaller test execution time.

It was needed to do changes in `quartz_solar_forecast/data.py` and `quartz_solar_forecast/forecasts/v2.py`, so that they both use a wrapper from `quartz_solar_forecast/weather/open_meteo.py`, which made it possible to mock data requesting-related method. Also it allowed to avoid some of the code duplication.

Fixes #231 

## How Has This Been Tested?

Workflow tests job for unit tests succeeds in fork branch, test execution time is about 3 minutes now.
![image](https://github.com/user-attachments/assets/3dac3d45-6687-40bf-88f0-1c86cb16a591)

Coverage changed slightly (59%->58%), seems to be due to amount of codelines decreasing 🙂
![image](https://github.com/user-attachments/assets/49da74cb-945c-4299-a10e-8277bb5c9b1a)

Job for integration tests is failing, but I guess it wasn't working already.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation - not sure if those needed
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
