### PR TITLE
Updated PVForecastForm to match backend API

### DIFF
--- a/dashboards/dashboard_1/src/components/PVForecastForm.tsx
+++ b/dashboards/dashboard_1/src/components/PVForecastForm.tsx
@@ -51,13 +51,13 @@ export function PVForecastForm({ updatePredictions }) {
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    const response = await fetch(`http://localhost:8000/forecast`, {
+    const response = await fetch(`http://localhost:8000/forecast/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(values),
+      body: JSON.stringify({ site: values }),
     });
     const data = await response.json();
-    updatePredictions(data.power_kw);
+    updatePredictions(data.predictions.power_kw);
   }
   return (
     <Form {...form}>


### PR DESCRIPTION
## Description/ Reason
The frontend request didn’t match the backend API:  

- Called `POST /forecast` (missing trailing slash) → 404  
- Sent raw form values instead of `{ site: { ... } }` → 422  
- Read `data.power_kw` instead of `data.predictions.power_kw` → empty UI  

This PR aligns the frontend with the FastAPI schema and the actual response shape so predictions render.  

## Fixes

- **File:** `dashboards/dashboard_1/src/components/PVForecastForm.tsx`  
  - Use `POST http://localhost:8000/forecast/` (with trailing slash)  
  - Wrap request body as `{ site: values }`  
  - Update response handling to `data.predictions.power_kw`  

## How Has This Been Tested?

1. Start backend:  
   ```bash
   python api/v0/main.py
   ```
2. Start frontend:  
   ```bash
   cd dashboards/dashboard_1
   npm install
   npm run dev
   ```
3. Open the dashboard, submit the **Predict** form with any values.  
4. Expect predictions to render without console or network errors.  

## Notes

- CORS already allows `http://localhost:5173` in `api/v0/app/main.py`.  
- No breaking changes to types or UI; just request/response alignment.  


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have added tests that prove my fix is effective or that my feature works, (I have not written any test as it is already test, but please mention if I should)
- [x] I have checked my code and corrected any misspellings
