### PR TITLE
Update Pydantic examples to display correctly in /docs and /redoc

### DIFF
--- a/api/v1/api.py
+++ b/api/v1/api.py
@@ -136,6 +136,24 @@ class ForecastRequest(BaseModel):
     live_generation: list[GenerationValue] | None = Field(
         None, description="Optional list of live generation values."
     )
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "site": {
+                    "latitude": 51.5072,
+                    "longitude": -0.1276,
+                    "capacity_kwp": 5.0,
+                    "tilt": 30,
+                    "orientation": 180
+                },
+                "timestamp": "2025-09-12T05:35:48.277Z",
+                "live_generation": [
+                    {"timestamp": "2025-09-12T05:00:00Z", "generation": 2.5},
+                    {"timestamp": "2025-09-12T04:45:00Z", "generation": 2.2}
+                ]
+            }
+        }
+    }
 
 @app.post("/forecast/")
 def forecast(forecast_request: ForecastRequest) -> ForecastResponse:

--- a/api/v1/api.py
+++ b/api/v1/api.py
@@ -115,12 +115,11 @@ class ForecastValues(BaseModel):
     )
 
 
-
 class GenerationValue(BaseModel):
     """Generation Value"""
+
     timestamp: datetime
     generation: float
-
 
 
 class ForecastResponse(BaseModel):
@@ -144,16 +143,17 @@ class ForecastRequest(BaseModel):
                     "longitude": -0.1276,
                     "capacity_kwp": 5.0,
                     "tilt": 30,
-                    "orientation": 180
+                    "orientation": 180,
                 },
                 "timestamp": "2025-09-12T05:35:48.277Z",
                 "live_generation": [
                     {"timestamp": "2025-09-12T05:00:00Z", "generation": 2.5},
-                    {"timestamp": "2025-09-12T04:45:00Z", "generation": 2.2}
-                ]
+                    {"timestamp": "2025-09-12T04:45:00Z", "generation": 2.2},
+                ],
             }
         }
     }
+
 
 @app.post("/forecast/")
 def forecast(forecast_request: ForecastRequest) -> ForecastResponse:
@@ -182,8 +182,6 @@ def forecast(forecast_request: ForecastRequest) -> ForecastResponse:
     else:
         live_generation_df = None
 
-
-
     site_no_live = PVSite(
         latitude=site.latitude,
         longitude=site.longitude,
@@ -193,7 +191,6 @@ def forecast(forecast_request: ForecastRequest) -> ForecastResponse:
     )
 
     predictions = run_forecast(site=site_no_live, ts=timestamp, live_generation=live_generation_df)
-
 
     response = {
         "timestamp": formatted_timestamp,

--- a/quartz_solar_forecast/pydantic_models.py
+++ b/quartz_solar_forecast/pydantic_models.py
@@ -16,20 +16,17 @@ class PVSite(BaseModel):
         description="the latitude of the site",
         ge=-90,
         le=90,
-        json_schema_extra={"examples": [51.5072]},
     )
     longitude: float = Field(
         ...,
         description="the longitude of the site",
         ge=-180,
         le=180,
-        json_schema_extra={"examples": [-0.1276]},
     )
     capacity_kwp: float = Field(
         ...,
         description="the capacity [kwp] of the site",
         ge=0,
-        json_schema_extra={"examples": [5.0]},
     )
     tilt: float = Field(
         default=35,

--- a/quartz_solar_forecast/pydantic_models.py
+++ b/quartz_solar_forecast/pydantic_models.py
@@ -11,9 +11,9 @@ from quartz_solar_forecast.inverters.victron import VictronInverter, VictronSett
 
 
 class PVSite(BaseModel):
-    latitude: float = Field(..., description="the latitude of the site", ge=-90, le=90)
-    longitude: float = Field(..., description="the longitude of the site", ge=-180, le=180)
-    capacity_kwp: float = Field(..., description="the capacity [kwp] of the site", ge=0)
+    latitude: float = Field(..., description="the latitude of the site", ge=-90, le=90,json_schema_extra={"examples": [51.5072]})
+    longitude: float = Field(..., description="the longitude of the site", ge=-180, le=180, json_schema_extra={"examples": [-0.1276]})
+    capacity_kwp: float = Field(..., description="the capacity [kwp] of the site", ge=0,json_schema_extra={"examples": [5.0]})
     tilt: float = Field(
         default=35,
         description=(

--- a/quartz_solar_forecast/pydantic_models.py
+++ b/quartz_solar_forecast/pydantic_models.py
@@ -11,9 +11,26 @@ from quartz_solar_forecast.inverters.victron import VictronInverter, VictronSett
 
 
 class PVSite(BaseModel):
-    latitude: float = Field(..., description="the latitude of the site", ge=-90, le=90,json_schema_extra={"examples": [51.5072]})
-    longitude: float = Field(..., description="the longitude of the site", ge=-180, le=180, json_schema_extra={"examples": [-0.1276]})
-    capacity_kwp: float = Field(..., description="the capacity [kwp] of the site", ge=0,json_schema_extra={"examples": [5.0]})
+    latitude: float = Field(
+        ...,
+        description="the latitude of the site",
+        ge=-90,
+        le=90,
+        json_schema_extra={"examples": [51.5072]},
+    )
+    longitude: float = Field(
+        ...,
+        description="the longitude of the site",
+        ge=-180,
+        le=180,
+        json_schema_extra={"examples": [-0.1276]},
+    )
+    capacity_kwp: float = Field(
+        ...,
+        description="the capacity [kwp] of the site",
+        ge=0,
+        json_schema_extra={"examples": [5.0]},
+    )
     tilt: float = Field(
         default=35,
         description=(


### PR DESCRIPTION
# Pull Request

## Description
This PR updates all relevant models (PVSite, ForecastRequest, etc.) to use the new Pydantic v2 syntax and replaces placeholder data (e.g. capacity=0, Antarctica coordinates) with realistic examples such as:

London latitude/longitude (51.5072, -0.1276)

Site capacity 5.0 kWp

Valid UTC timestamps

Example live generation values

Fixes #290 

## How Has This Been Tested?
Tested locally

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/ca32662c-9756-4e29-8ee6-fbe7501c457f" />
