### PR TITLE
Pin numexpr and sentry-sdk deps to fix pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,11 @@ dependencies = [
     "uvicorn",
     "pydantic_settings",
     "httpx",
-    "sentry_sdk",
-    "huggingface_hub==0.17.3"
+    "huggingface_hub==0.17.3",
+    # Temporarily pin these to allow simple `pip install` to work
+    # see https://github.com/openclimatefix/open-source-quartz-solar-forecast/issues/316
+    "numexpr==2.13.1",
+    "sentry-sdk==2.37.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
# Pull Request

## Description

Motivation: The simple `pip install` examples from the project README and various presentation videos no longer work because the larger Python ecosystem has moved on since 3.11.

See openclimatefix/open-source-quartz-solar-forecast#316

Specifically, `quartz_solar_forecast` cannot be trivially upgraded to support Python 3.12+ because of concerns about the compatibility of the existing models. See openclimatefix/open-source-quartz-solar-forecast#93

Ideally, these dependencies would be unpinned along with moving to newer versions of numpy and the Hugging Face Hub API which should both unblock newer versions of Python and allow for an unqualified `pip install` to work for this package.

Fixes openclimatefix/open-source-quartz-solar-forecast#316

## How Has This Been Tested?

`uv sync` succeeds within this package. Also see my description in openclimatefix/open-source-quartz-solar-forecast#316 for how I arrived at this strategy.

- [X] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] ~~Yes~~ N/A

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~ N/A
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ N/A
- [x] I have checked my code and corrected any misspellings
