### PR TITLE
Fix import-time crash by making Sentry initialization conditional

### DIFF
--- a/quartz_solar_forecast/utils/sentry_logging.py
+++ b/quartz_solar_forecast/utils/sentry_logging.py
@@ -14,7 +14,8 @@ quartz_solar_forecast_logging = (
 )
 
 SENTRY_DSN = "https://b2b6f3c97299f81464bc16ad0d516d0b@o400768.ingest.us.sentry.io/4508439933157376"
-sentry_sdk.init(dsn=SENTRY_DSN, traces_sample_rate=1.0)
+if quartz_solar_forecast_logging:
+    sentry_sdk.init(dsn=SENTRY_DSN, traces_sample_rate=1.0)
 
 
 def write_sentry(params):

--- a/quartz_solar_forecast/utils/sentry_logging.py
+++ b/quartz_solar_forecast/utils/sentry_logging.py
@@ -14,8 +14,17 @@ quartz_solar_forecast_logging = (
 )
 
 SENTRY_DSN = "https://b2b6f3c97299f81464bc16ad0d516d0b@o400768.ingest.us.sentry.io/4508439933157376"
+
 if quartz_solar_forecast_logging:
-    sentry_sdk.init(dsn=SENTRY_DSN, traces_sample_rate=1.0)
+    def filter_integrations(integrations):
+        try:
+            from sentry_sdk.integrations.huggingface_hub import HuggingFaceHubIntegration
+
+            return [i for i in integrations if not isinstance(i, HuggingFaceHubIntegration)]
+        except (ImportError, AttributeError):
+            return integrations
+
+    sentry_sdk.init(dsn=SENTRY_DSN, traces_sample_rate=1.0, integrations=filter_integrations)
 
 
 def write_sentry(params):


### PR DESCRIPTION
## Description

This PR fixes an import-time crash caused by unconditional `sentry_sdk.init()` in `quartz_solar_forecast/utils/sentry_logging.py`.

Sentry is now initialized **only when `QUARTZ_SOLAR_FORECAST_LOGGING` is enabled**, preventing telemetry or integration issues from breaking imports and respecting user configuration.

Fixes #326 

## How Has This Been Tested?

* Manually tested by importing `quartz_solar_forecast` with `QUARTZ_SOLAR_FORECAST_LOGGING=false`

* Verified that `sentry_sdk.init()` is not called and `SENTRY_CLIENT` remains `None`

* Confirmed that the package imports successfully without crashing

* [x] Yes

*If your changes affect data processing, have you plotted any changes?*
Not applicable (logging/telemetry change only)

* [x] Yes

## Checklist:

* [x] My code follows OCF's coding style guidelines
* [x] I have performed a self-review of my own code
* [ ] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] I have checked my code and corrected any misspellings
