### PR TITLE
ci: migrate to reusable workflows

### DIFF
--- a/.github/workflows/api_branch_ci.yaml
+++ b/.github/workflows/api_branch_ci.yaml
@@ -1,10 +1,13 @@
 name: API Tests + Docker build (branch)
 run-name: 'Test branch commit "${{ github.event.head_commit.message }}"'
 
-on:  
-  push:
-    branches-ignore: [ "main" ]
-    paths-ignore: ['README.md']
+# on:  
+  # push:
+    # branches-ignore: [ "main" ]
+    # paths-ignore: ['README.md']
+on:
+  workflow_dispatch:
+
 
 jobs:
   branch_ci:

--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -1,0 +1,12 @@
+name: Branch CI
+
+on:
+  push:
+    branches-ignore: ["main"]
+  pull_request:
+
+jobs:
+  run-ci:
+    uses: openclimatefix/.github/.github/workflows/branch_ci@main
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,16 +1,21 @@
 name: Python package tests - integration
 
+# on:
+  # push:
+  # schedule:
+    # - cron: "0 12 * * 1"
 on:
-  push:
   schedule:
     - cron: "0 12 * * 1"
+  workflow_dispatch:
+
 
 jobs:
 
   call-run-python-tests-integration:
     # only run on push, not external PR
     uses: openclimatefix/.github/.github/workflows/python-test.yml@issue/pip-all
-    if: github.event_name == 'push'
+    
     with:
       # pytest-cov looks at this folder
       pytest_cov_dir: "quartz_solar_forecast"

--- a/.github/workflows/pytest_unit.yaml
+++ b/.github/workflows/pytest_unit.yaml
@@ -1,14 +1,17 @@
 name: Unit Tests(branch)
 run-name: 'Test branch commit "${{ github.event.head_commit.message }}"'
 
-on:  
-  push:
-    branches-ignore: [ "main" ]
-    paths-ignore: ['README.md']
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+# on:  
+  # push:
+    # branches-ignore: [ "main" ]
+    # paths-ignore: ['README.md']
+  # pull_request:
+    # types: [opened, synchronize, reopened]
+  # pull_request_target:
+    # types: [opened, synchronize, reopened, ready_for_review]
+on:
+  workflow_dispatch:
+
 
 jobs:
   branch_ci:


### PR DESCRIPTION
## Description

Migrates the repository to use OpenClimateFix reusable GitHub Actions workflows.
Legacy branch and PR workflows have been disabled to avoid duplicate CI runs, while preserving scheduled jobs.
This aligns the repo with the new organisation-wide CI setup and ensures `HF_TOKEN` is passed correctly where required.

Related to openclimatefix/.github#86

## How Has This Been Tested?

This change updates CI configuration only.  
Testing is handled by GitHub Actions: the updated reusable workflows will run automatically on this PR and verify the setup.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings

