### PR TITLE
Fix inconsistent(race-condition) start_date/start_time around midnight in predict_tryolabs

### DIFF
--- a/quartz_solar_forecast/forecast.py
+++ b/quartz_solar_forecast/forecast.py
@@ -80,11 +80,13 @@ def predict_tryolabs(site: PVSite, ts: datetime | str = None):
 
     # set start and end time, if no time is given use current time
     if ts is None:
-        start_date = pd.Timestamp.now().strftime("%Y-%m-%d")
-        start_time = pd.Timestamp.now().round(freq="h")
+        now = pd.Timestamp.now()
+        start_date = now.strftime("%Y-%m-%d")
+        start_time = now.round(freq="h")
     else:
-        start_date = pd.Timestamp(ts).strftime("%Y-%m-%d")
-        start_time = pd.Timestamp(ts).round(freq="h")
+        ts_pd = pd.Timestamp(ts)
+        start_date = ts_pd.strftime("%Y-%m-%d")
+        start_time = ts_pd.round(freq="h")
 
     end_time = start_time + pd.Timedelta(hours=48)
     start_date_datetime = datetime.strptime(start_date, "%Y-%m-%d")


### PR DESCRIPTION
# Pull Request

## Description

Fixes a boundary bug in the `predict_tryolabs` branch where `pd.Timestamp.now()` was called twice when `ts=None`.

This patch captures the current time once and derives both `start_time` and `start_date` from the same timestamp, guaranteeing alignment and preventing data loss around midnight.

Fixes #321 

## How Has This Been Tested?
This performs well on the mentioned race condition.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

