### PR TITLE
fix: Remove trailing whitespace from open_meteo.py line 102 (W293)

### DIFF
--- a/quartz_solar_forecast/weather/open_meteo.py
+++ b/quartz_solar_forecast/weather/open_meteo.py
@@ -99,7 +99,7 @@ class WeatherService:
             raise ValueError(
                 f"Invalid date format. Please use YYYY-MM-DD format. Error: {str(e)}"
             ) from e
-        
+
         if not (end_datetime > start_datetime):
             raise ValueError(
                 f"Invalid date range. End date ({end_date}) must be greater than "


### PR DESCRIPTION
# Pull Request

## Description

Fixes lint error W293 (blank line contains whitespace) at line 102 of [quartz_solar_forecast/weather/open_meteo.py](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/open-source-quartz-solar-forecast/quartz_solar_forecast/weather/open_meteo.py:0:0-0:0).

This is a quick fix to unblock CI checks that are failing due to this whitespace issue. The `pull_request_target` workflow runs against the `main` branch, which currently has trailing whitespace on line 102. This causes all PRs to fail the `lint-typecheck (pull_request_target)` check.

Fixes the CI blocker for PR #339 and other open PRs.

## How Has This Been Tested?

- [x] Yes

Ran `ruff check quartz_solar_forecast/weather/open_meteo.py` locally to confirm no lint errors after the fix.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings