### PR TITLE
Add optional APITally monitoring support to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ and how we can make improvements in the future.
 Note that any latitudes and longitudes are rounded to 2 decimals places in order to anonymize the data.
 If you would like to disable this logging, you can do so by setting the environment variable `QUARTZ_SOLAR_FORECAST_LOGGING` to `False`.
 
+### API Monitoring (APITally)
+
+The FastAPI application supports optional monitoring via APITally.
+
+To enable API request monitoring, set the following environment variables before starting the API:
+
+```bash
+APITALLY_CLIENT_ID=your_client_id
+APITALLY_ENVIRONMENT=dev
+```
+
+
 
 ## Model
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To enable API request monitoring, set the following environment variables before
 
 ```bash
 export APITALLY_CLIENT_ID=your_client_id
-export APITALLY_ENVIRONMENT=local
+export APITALLY_ENVIRONMENT=open_quartz_local
 ```
 
 ## Model

--- a/README.md
+++ b/README.md
@@ -96,11 +96,9 @@ The FastAPI application supports optional monitoring via APITally.
 To enable API request monitoring, set the following environment variables before starting the API:
 
 ```bash
-APITALLY_CLIENT_ID=your_client_id
-APITALLY_ENVIRONMENT=dev
+export APITALLY_CLIENT_ID=your_client_id
+export APITALLY_ENVIRONMENT=local
 ```
-
-
 
 ## Model
 

--- a/api/v1/api.py
+++ b/api/v1/api.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from importlib.metadata import version
 
 import pandas as pd
+from apitally.fastapi import ApitallyMiddleware
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
@@ -94,6 +95,16 @@ And you can always head over to our
 
 
 app = FastAPI(description=description, version=__version__, title="Open Quartz Solar Forecast API")
+
+client_id = os.getenv("APITALLY_CLIENT_ID")
+
+if client_id:
+    app.add_middleware(
+        ApitallyMiddleware,
+        client_id=client_id,
+        environment=os.getenv("APITALLY_ENVIRONMENT", "dev"),
+    )
+
 
 # CORS middleware setup
 origins = [

--- a/api/v1/api.py
+++ b/api/v1/api.py
@@ -102,10 +102,13 @@ if client_id:
     app.add_middleware(
         ApitallyMiddleware,
         client_id=client_id,
-        environment=os.getenv("APITALLY_ENVIRONMENT", "dev"),
+        environment=os.getenv("APITALLY_ENVIRONMENT", "local"),
+        enable_request_logging=True,
+        log_request_headers=True,
+        log_request_body=True,
+        log_response_body=True,
+        capture_logs=True,
     )
-
-
 # CORS middleware setup
 origins = [
     "*",

--- a/api/v1/api.py
+++ b/api/v1/api.py
@@ -102,7 +102,7 @@ if client_id:
     app.add_middleware(
         ApitallyMiddleware,
         client_id=client_id,
-        environment=os.getenv("APITALLY_ENVIRONMENT", "local"),
+        environment=os.getenv("APITALLY_ENVIRONMENT", "open_quartz_local"),
         enable_request_logging=True,
         log_request_headers=True,
         log_request_body=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "pydantic_settings",
     "httpx",
     "sentry_sdk",
-    "huggingface_hub==0.17.3"
+    "huggingface_hub==0.17.3",
+    "apitally[fastapi]>=0.22.3"
 ]
 
 [project.urls]
@@ -51,6 +52,7 @@ dev = [
     "matplotlib",
     "zipfile36",
     "pytest",
+    "huggingface_hub==0.17.3"
 ]
 inverters = ["ocf_vrmapi"] # victron
 all = [
@@ -60,6 +62,7 @@ all = [
     "gdown==5.1.0",
     "fastapi",
     "pytest",
+    "huggingface_hub==0.17.3"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
# Pull Request

## Description

This PR adds optional API monitoring support using APITally to the FastAPI application.

### Changes

- Added `ApitallyMiddleware` integration in `api/v1/api.py`
- Added `apitally[fastapi]>=0.22.3` to project dependencies
- Updated README with configuration instructions

The middleware is only enabled when the `APITALLY_CLIENT_ID` environment variable is set, ensuring no behavior change for users who do not configure it.

This improves API observability while keeping monitoring optional and non-intrusive

Fixes #346 

## How Has This Been Tested?

Ran the API locally using:

```bash

uvicorn api.v1.api:app --reload
```

Verified the API runs correctly without APITALLY_CLIENT_ID

Verified middleware loads correctly when APITALLY_CLIENT_ID is set

Confirmed /docs endpoint works as expected

Confirmed /forecast/ endpoint still returns valid predictions
- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings