### PR TITLE
perf: vectorize get_pv_truth to eliminate iterrows and per-horizon selects

### DIFF
--- a/quartz_solar_forecast/eval/pv.py
+++ b/quartz_solar_forecast/eval/pv.py
@@ -44,9 +44,17 @@ def get_pv_metadata(testset: pd.DataFrame):
 
 
 def get_pv_truth(testset: pd.DataFrame):
+    """Extract PV ground-truth values for all test entries and forecast horizons.
+
+    Vectorized implementation: expands all (pv_id, timestamp, horizon) combinations
+    in one step, then batch-selects from the xarray dataset. Avoids per-row iterrows()
+    and per-horizon xarray.sel() calls.
+
+    Closes #344.
+    """
     print("Loading PV data")
 
-    # download from hugginface or load from cache
+    # download from huggingface or load from cache
     cache_dir = "data/pv"
     metadata_file = f"{cache_dir}/pv.netcdf"
     if not os.path.exists(metadata_file):
@@ -57,37 +65,38 @@ def get_pv_truth(testset: pd.DataFrame):
     # Load in the dataset
     pv_ds = xr.open_dataset(metadata_file, engine="h5netcdf")
 
-    combined_data = []
-    for index, row in testset.iterrows():
-        print(f"Processing {index} of {len(testset)}")
-        pv_id = str(row["pv_id"])
-        base_datetime = pd.to_datetime(row["timestamp"])
+    # Build all (pv_id, base_timestamp, horizon) combinations at once
+    horizons = np.arange(0, 49)  # 0 to 48 hours
+    testset = testset.copy()
+    testset["timestamp"] = pd.to_datetime(testset["timestamp"])
+    testset["pv_id"] = testset["pv_id"].astype(str)
 
-        # Calculate future timestamps up to the max horizon
-        for i in range(0, 49):  # 48 hours in steps of 1 hour
-            future_datetime = base_datetime + pd.DateOffset(hours=i)
-            horizon = i  # horizon in hours
+    # Cross-join testset with horizons — one row per (test_entry, horizon)
+    expanded = testset.loc[testset.index.repeat(len(horizons))].reset_index(drop=True)
+    expanded["horizon_hour"] = np.tile(horizons, len(testset))
+    expanded["timestamp"] = expanded["timestamp"] + pd.to_timedelta(expanded["horizon_hour"], unit="h")
 
-            try:
-                # Attempt to select data for the future datetime
-                selected_data = pv_ds[pv_id].sel(datetime=future_datetime)
-                value = selected_data.values.item()
-                value = value / 1000  # to convert from w to kw
-            except KeyError:
-                # If data is not found for the future datetime, set value as NaN
-                value = np.nan
+    # Batch-extract values from xarray: group by pv_id to minimize dataset access
+    print(f"Extracting {len(expanded)} values across {expanded['pv_id'].nunique()} PV systems")
+    values = np.full(len(expanded), np.nan)
 
-            # Add the data to the DataFrame
-            combined_data.append(
-                pd.DataFrame(
-                    {
-                        "pv_id": pv_id,
-                        "timestamp": future_datetime,
-                        "value": value,
-                        "horizon_hour": horizon,
-                    },
-                    index=[i],
-                )
-            )
-    combined_data = pd.concat(combined_data)
-    return combined_data
+    for pv_id, group in expanded.groupby("pv_id"):
+        if pv_id not in pv_ds:
+            continue
+
+        pv_series = pv_ds[pv_id]
+        available_times = pd.DatetimeIndex(pv_series.datetime.values)
+
+        # Find which requested timestamps exist in the dataset
+        requested_times = group["timestamp"].values
+        mask = np.isin(requested_times, available_times)
+
+        if mask.any():
+            matched_times = requested_times[mask]
+            selected = pv_series.sel(datetime=matched_times).values / 1000  # W to kW
+            values[group.index[mask]] = selected
+
+    expanded["value"] = values
+
+    print(f"Extracted {np.isfinite(values).sum()} valid values out of {len(values)} total")
+    return expanded[["pv_id", "timestamp", "value", "horizon_hour"]]


### PR DESCRIPTION
## Summary

Closes #344. Replaces the row-wise `iterrows()` + nested horizon loop in `get_pv_truth()` with a vectorized approach.

**Before:**
- `iterrows()` over testset x 49 horizons = N x 49 individual xarray `.sel()` calls
- Each select creates a new DataFrame and appends to a list
- O(N x 49) xarray point lookups

**After:**
- One expansion step using `np.tile` + `pd.to_timedelta` (vectorized)
- One `groupby('pv_id')` with batch `.sel()` per PV system
- `np.isin` for timestamp matching instead of try/except per value
- O(unique_pv_ids) xarray accesses instead of O(N x 49)

## What changed

`quartz_solar_forecast/eval/pv.py` - `get_pv_truth()` rewritten to:
1. Expand all (pv_id, timestamp, horizon) combinations in one step
2. Group by pv_id and batch-select from xarray
3. Use numpy boolean indexing for timestamp matching

Output format is identical: DataFrame with columns `pv_id, timestamp, value, horizon_hour`.

## Test plan

- [ ] Run eval pipeline with existing testset and compare output shape/values
- [ ] Verify NaN handling matches original (missing timestamps -> NaN)