### PR TITLE
fix: bump requests-cache dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pydantic==2.6.2",
     "python-dotenv==1.0.1",
     "openmeteo-requests==1.2.0",
-    "requests-cache==1.2.0",
+    "requests-cache==1.3.2",
     "retry-requests==2.0.0",
     "xgboost==2.0.3",
     "typer",


### PR DESCRIPTION
## Summary

- Bump `requests-cache` from `1.2.0` to `1.3.2`
- Keeps the existing exact-pin dependency style used in `pyproject.toml`
- Addresses the currently reproducible dependency/runtime failure discussed in #316
- Addresses the same `RequestsCookieJar` runtime failure currently visible in the unit-test CI logs

## Reproduction

With the current `main` dependency pin, `examples/example.py` fails after fetching Open-Meteo data:

```text
NameError: name 'RequestsCookieJar' is not defined
```

The failure comes from `requests-cache==1.2.0` serializing/deserializing cached responses with current transitive dependencies.

## CI note

The currently failing visible unit-test check on this fork PR is a `pull_request_target` run that checks out upstream `main`, so it installs `requests-cache==1.2.0` and reproduces the same `RequestsCookieJar` failure before this PR branch is actually tested. This PR addresses the underlying dependency/runtime failure; it does not change the workflow checkout behavior.

## Verification

```bash
uv sync
.venv/bin/python examples/example.py
.venv/bin/python -m pytest tests/unit -q
```

Result:

```text
examples/example.py -> [192 rows x 1 columns]
tests/unit -> 22 passed, 4 warnings
```

I also verified a clean installed-package path outside the source tree:

```bash
python3.11 -m venv /private/tmp/ocf-902-pr-venv
/private/tmp/ocf-902-pr-venv/bin/python -m pip install /path/to/Open-Source-Quartz-Solar-Forecast
/private/tmp/ocf-902-pr-venv/bin/python - <<'PY'
from datetime import datetime
from quartz_solar_forecast.forecast import run_forecast
from quartz_solar_forecast.pydantic_models import PVSite

site = PVSite(latitude=51.75, longitude=-1.25, capacity_kwp=1.25)
predictions_df = run_forecast(site=site, ts=datetime.today(), nwp_source="icon")
print(predictions_df.shape)
print(predictions_df["power_kw"].max())
PY
```

Result:

```text
(192, 1)
```