### PR TITLE
test: fix forecast csv mock target

### DIFF
--- a/tests/unit/test_generate_forecast.py
+++ b/tests/unit/test_generate_forecast.py
@@ -1,9 +1,11 @@
 import os
-import pandas as pd
 from datetime import datetime, timedelta
-import quartz_solar_forecast.forecast as forecast
-from quartz_solar_forecast.utils.forecast_csv import write_out_forecasts
+
+import pandas as pd
+
+import quartz_solar_forecast.utils.forecast_csv as forecast_csv
 from quartz_solar_forecast.pydantic_models import PVSite
+
 
 def test_generate_forecast(monkeypatch):
     site_name = "TestCase"
@@ -36,12 +38,12 @@ def test_generate_forecast(monkeypatch):
             }
         )
 
-    monkeypatch.setattr(forecast, "run_forecast", mock_forecast)
+    monkeypatch.setattr(forecast_csv, "run_forecast", mock_forecast)
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
-    write_out_forecasts(
+    forecast_csv.write_out_forecasts(
         init_time_freq,
         start_datetime,
         end_datetime,


### PR DESCRIPTION
# Pull Request

## Description

Addresses #231.

This is a small test-only follow-up to the slow CI/unit-test investigation. `tests/unit/test_generate_forecast.py` already tried to mock `run_forecast`, but it patched `quartz_solar_forecast.forecast.run_forecast`. The code under test imports `run_forecast` directly into `quartz_solar_forecast.utils.forecast_csv`, so the mock did not intercept the call and the unit test still exercised the real forecast path.

This changes the test to patch `quartz_solar_forecast.utils.forecast_csv.run_forecast`, which is the symbol actually used by `write_out_forecasts`.

Performance / CI relevance:

- Before this change, local instrumentation showed `test_generate_forecast` made 5 live Open-Meteo calls.
- After this change, the same test passes with `Open-Meteo calls: 0`.
- The targeted test body is reported by pytest as `0.01s` with `--durations=0`.

This intentionally does not try to solve all of #231 in one PR. Other unit tests still make live Open-Meteo calls, so this is a narrow first step rather than a full closure.

## How Has This Been Tested?

```bash
uv sync
.venv/bin/python -m ruff check tests/unit/test_generate_forecast.py
.venv/bin/python -m pytest tests/unit/test_generate_forecast.py::test_generate_forecast -q --durations=0
```

Results:

- Ruff: `All checks passed!`
- Targeted pytest: `1 passed`; slowest call `0.01s`
- Guard check with `openmeteo_requests.Client.weather_api` patched to fail: `1 passed`, `Open-Meteo calls: 0`

I also ran the full unit suite with a local `requests-cache==1.3.2` override because current `main` is affected by the separate `requests-cache==1.2.0` issue:

```bash
uv pip install requests-cache==1.3.2
.venv/bin/python -m pytest tests/unit -q --durations=15
```

Result: `22 passed, 4 warnings in 171.77s`. The suite is still slow because other unit tests continue to call live weather APIs; those should be addressed separately.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation - not needed for this test-only fix
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
