### PR TITLE
test: mock forecast in API unit tests

### DIFF
--- a/tests/unit/api_tests/conftest.py
+++ b/tests/unit/api_tests/conftest.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def mock_run_forecast():
+    """Return a deterministic forecast without calling weather APIs."""
+
+    def _mock_run_forecast(*args, **kwargs):
+        index = pd.date_range(datetime(2021, 1, 26, 1, 15), periods=192, freq="15min")
+        return pd.DataFrame({"power_kw": [0.0] * 192}, index=index)
+
+    return _mock_run_forecast

--- a/tests/unit/api_tests/v0/test_api.py
+++ b/tests/unit/api_tests/v0/test_api.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 
-from api.v0.api import app
+import api.v0.api as api
 
 expected_prediction_key = "power_kw"
 expected_dict_keys = ["timestamp", "predictions"]
@@ -59,7 +59,7 @@ envs = {
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    return TestClient(api.app)
 
 
 @pytest.fixture
@@ -114,7 +114,9 @@ def bad_redirect_url_correct_param(client):
     return "url?code=code"
 
 
-def test_api_ok(client, body):
+def test_api_ok(client, body, monkeypatch, mock_run_forecast):
+    monkeypatch.setattr(api, "run_forecast", mock_run_forecast)
+
     response = client.post("/forecast/", json=body)
     response_body = response.json()
     assert response.status_code == 200
@@ -127,7 +129,9 @@ def test_api_ok(client, body):
     ), "Expected number of values is wrong"
 
 
-def test_api_ok_short(client, body_short):
+def test_api_ok_short(client, body_short, monkeypatch, mock_run_forecast):
+    monkeypatch.setattr(api, "run_forecast", mock_run_forecast)
+
     response = client.post("/forecast/", json=body_short)
     response_body = response.json()
 

--- a/tests/unit/api_tests/v1/test_api_v1.py
+++ b/tests/unit/api_tests/v1/test_api_v1.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 
-from api.v1.api import app
+import api.v1.api as api
 
 expected_prediction_key = "power_kw"
 expected_dict_keys = ["timestamp", "predictions"]
@@ -52,7 +52,7 @@ expected_response_on_wrong_types = {
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    return TestClient(api.app)
 
 
 @pytest.fixture
@@ -113,7 +113,9 @@ def bad_redirect_url_correct_param(client):
     return "url?code=code"
 
 
-def test_api_ok(client, body):
+def test_api_ok(client, body, monkeypatch, mock_run_forecast):
+    monkeypatch.setattr(api, "run_forecast", mock_run_forecast)
+
     response = client.post("/forecast/", json=body)
     response_body = response.json()
     assert response.status_code == 200
@@ -126,7 +128,9 @@ def test_api_ok(client, body):
     ), "Expected number of values is wrong"
 
 
-def test_api_ok_short(client, body_short):
+def test_api_ok_short(client, body_short, monkeypatch, mock_run_forecast):
+    monkeypatch.setattr(api, "run_forecast", mock_run_forecast)
+
     response = client.post("/forecast/", json=body_short)
     response_body = response.json()
 
@@ -145,5 +149,4 @@ def test_api_wrong_body(client, body_wrong):
 
     assert response.status_code == 422
     assert response_body == expected_response_on_wrong_types
-
 


### PR DESCRIPTION
# Pull Request

## Description

Addresses #231.

This is a small, test-only change that makes the API unit tests deterministic by mocking the forecast function at the API module boundary.

The API success tests are checking request/response behavior and response shape. They do not need to call the real forecast pipeline or live Open-Meteo APIs. This PR patches the symbols used by the endpoints directly:

- `api.v0.api.run_forecast`
- `api.v1.api.run_forecast`

The fake forecast returns a 192-row `DataFrame` with a `power_kw` column, preserving the existing response-shape assertions.

Performance / CI relevance:

- Before this change, local instrumentation showed the API unit tests made 5 live Open-Meteo calls.
- After this change, the API unit tests pass with `Open-Meteo calls: 0`.
- The API test subset now passes locally in about 2 seconds.

This PR stands on its own and is based on current `main`. It does not depend on #363 or #362 being merged. It is also intentionally not a full closure of #231: other forecast unit tests still call live weather APIs and should be handled separately.

## How Has This Been Tested?

```bash
uv sync
.venv/bin/python -m pytest tests/unit/api_tests -q --durations=0
.venv/bin/python -m ruff check .
```

Results:

- API tests: `8 passed, 3 warnings in 1.75s`
- Repo-normal Ruff: `All checks passed!`

I also ran a guard check with `openmeteo_requests.Client.weather_api` patched to fail if called:

```bash
.venv/bin/python - <<'PY'
import openmeteo_requests
import pytest

calls = 0

def fail_if_called(self, url, params=None, method="GET"):
    global calls
    calls += 1
    raise AssertionError(f"Unexpected Open-Meteo call to {url}")

openmeteo_requests.Client.weather_api = fail_if_called
code = pytest.main(["tests/unit/api_tests", "-q"])
print(f"Open-Meteo calls: {calls}")
raise SystemExit(code)
PY
```

Result: `8 passed`, `Open-Meteo calls: 0`.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation - not needed for this test-only fix
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
