### PR TITLE
docs: update installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ To set up the development environment for this project, follow these steps:
 
 3. **Install the required dependencies:**
   ```bash
-  pip install -r requirements.txt
+  pip install -e .
   ```
 
 4. **Run the Jupyter Notebook server:**


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the installation instructions in the `README.md`. 

1. **Fix Missing `requirements.txt` reference:** The README currently instructs to install dependencies via `requirements.txt`. Updated instructions to direct users to use `pip install -e .` instead.

Fixes #365

## How Has This Been Tested?

The setup is verified locally in a fresh Python 3.11 virtual environment.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings