### PR TITLE
eval: fix the MAE confidence interval (hardcoded n=50) and return metrics as a dataframe

### DIFF
--- a/quartz_solar_forecast/eval/metrics.py
+++ b/quartz_solar_forecast/eval/metrics.py
@@ -2,6 +2,39 @@ import numpy as np
 import pandas as pd
 
 
+def bootstrap_mae_ci(
+    error_df: pd.DataFrame, n_boot: int = 1000, alpha: float = 0.05, seed: int = 42
+):
+    """Percentile-bootstrap confidence interval for the MAE, resampling sites.
+
+    Errors from the same PV site are correlated (same weather, same panel),
+    so the independent unit for resampling is the site, not the row. Sites
+    (pv_id) are resampled with replacement and the MAE recomputed for each
+    resample.
+
+    error_df needs columns:
+    - pv_id
+    - abs_error
+
+    Returns (ci_low, ci_high); (nan, nan) if fewer than two sites.
+    """
+    site_errors = {
+        pv_id: group["abs_error"].to_numpy() for pv_id, group in error_df.groupby("pv_id")
+    }
+    pv_ids = list(site_errors)
+    if len(pv_ids) < 2:
+        return (np.nan, np.nan)
+    rng = np.random.default_rng(seed)
+    boot_maes = np.empty(n_boot)
+    for i in range(n_boot):
+        chosen = rng.choice(len(pv_ids), size=len(pv_ids), replace=True)
+        boot_maes[i] = np.concatenate([site_errors[pv_ids[j]] for j in chosen]).mean()
+    return (
+        float(np.quantile(boot_maes, alpha / 2)),
+        float(np.quantile(boot_maes, 1 - alpha / 2)),
+    )
+
+
 def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: bool = False):
     """
     Calculate and print metrics: MAE
@@ -19,6 +52,12 @@ def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: 
     - pv_id
     - capacity
 
+    Returns a dataframe with one row per horizon group:
+    - horizon_group
+    - n (rows in the group)
+    - mae
+    - mae_ci_low / mae_ci_high (95% site-bootstrap interval)
+    - mae_normalized
     """
 
     # remove night time
@@ -27,8 +66,11 @@ def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: 
 
     # merge pv_metadata with results_df
     results_df = pd.merge(results_df, pv_metadata, on="pv_id")
+    results_df = results_df.assign(
+        abs_error=(results_df["forecast_power"] - results_df["generation_power"]).abs()
+    )
 
-    mae = np.round((results_df["forecast_power"] - results_df["generation_power"]).abs().mean(), 4)
+    mae = np.round(results_df["abs_error"].mean(), 4)
     mae_normalized = np.round(
         ((results_df["forecast_power"] - results_df["generation_power"]) / results_df["capacity"])
         .abs()
@@ -43,25 +85,15 @@ def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: 
     horizon_groups = [[x, x] for x in horizon_hours]
     horizon_groups += [[3, 4], [5, 8], [9, 16], [17, 24], [24, 48], [0, 36]]
 
+    rows = []
     for horizon_group in horizon_groups:
         horizon_group_df = results_df[
             results_df["horizon_hour"].between(horizon_group[0], horizon_group[1])
         ]
-        mae = np.round(
-            (horizon_group_df["forecast_power"] - horizon_group_df["generation_power"])
-            .abs()
-            .mean(),
-            3,
-        )
-        sem = np.round(
-            (
-                (horizon_group_df["forecast_power"] - horizon_group_df["generation_power"])
-                .abs()
-                .std()
-                / 50**0.5
-            ),
-            3,
-        )
+        if len(horizon_group_df) == 0:
+            continue
+        mae = np.round(horizon_group_df["abs_error"].mean(), 3)
+        ci_low, ci_high = bootstrap_mae_ci(horizon_group_df)
 
         mae_normalized = np.round(
             (
@@ -74,8 +106,20 @@ def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: 
         )
 
         print(
-            f"MAE for horizon {horizon_group}: {mae} +- {1.96 * sem:.3g}. "
+            f"MAE for horizon {horizon_group}: {mae} "
+            f"[{ci_low:.3g}, {ci_high:.3g}] (95% CI over sites, n={len(horizon_group_df)}). "
             f"mae_normalized: {100 * mae_normalized:.3g} %"
         )
 
-        # TODO add more metrics using ocf_ml_metrics
+        rows.append(
+            {
+                "horizon_group": f"{horizon_group[0]}-{horizon_group[1]}",
+                "n": len(horizon_group_df),
+                "mae": mae,
+                "mae_ci_low": ci_low,
+                "mae_ci_high": ci_high,
+                "mae_normalized": mae_normalized,
+            }
+        )
+
+    return pd.DataFrame(rows)

--- a/tests/unit/eval/test_metrics.py
+++ b/tests/unit/eval/test_metrics.py
@@ -1,30 +1,100 @@
-from quartz_solar_forecast.eval.metrics import metrics
-import pandas as pd
 import numpy as np
+import pandas as pd
+
+from quartz_solar_forecast.eval.metrics import bootstrap_mae_ci, metrics
 
 
-def test_metrics():
+def make_results(pv_ids, horizon_hour, rows_per_site, rng, error_scale=None, error=None):
+    """Generation is daytime (>0.1) and forecast is generation plus a known
+    error, so the MAE is known by construction. Errors are drawn PER ROW when
+    error_scale is given — identical error sets across sites would make the
+    site-bootstrap degenerate and the test would assert nothing."""
+    rows = []
+    for pv_id in pv_ids:
+        for _ in range(rows_per_site):
+            generation = 1.0 + rng.random()
+            e = error if error is not None else rng.normal(0, error_scale)
+            rows.append(
+                {
+                    "pv_id": pv_id,
+                    "timestamp": "2024-01-01 12:00",
+                    "horizon_hour": horizon_hour,
+                    "forecast_power": generation + e,
+                    "generation_power": generation,
+                }
+            )
+    return pd.DataFrame(rows)
 
-    # create a fake dataframe
 
-    results_df = pd.DataFrame(
-        columns=[
-            "pv_id",
-            "timestamp",
-            "horizon_hour",
-            "forecast_power",
-            "generation_power",
-        ],
-        data=np.random.random((100, 5)),
+def make_metadata(df):
+    return pd.DataFrame({"pv_id": df["pv_id"].unique(), "capacity": 2.0})
+
+
+def test_mae_matches_known_errors_and_result_is_returned():
+    rng = np.random.default_rng(0)
+    # constant +0.2 error everywhere -> MAE is exactly 0.2 in every group
+    results_df = make_results(pv_ids=range(5), horizon_hour=1, rows_per_site=8, rng=rng, error=0.2)
+    out = metrics(results_df, make_metadata(results_df))
+
+    assert isinstance(out, pd.DataFrame)
+    assert set(out.columns) == {
+        "horizon_group",
+        "n",
+        "mae",
+        "mae_ci_low",
+        "mae_ci_high",
+        "mae_normalized",
+    }
+    assert (out["mae"] == 0.2).all()
+    # constant errors: every site resample gives the same MAE (up to float eps)
+    assert np.allclose(out["mae_ci_low"], 0.2)
+    assert np.allclose(out["mae_ci_high"], 0.2)
+
+
+def test_ci_width_tracks_the_number_of_sites():
+    # Regression test for the previous hardcoded n=50 SEM: a group with few
+    # sites must report a wider interval than a group with many sites drawn
+    # from the same error distribution.
+    rng = np.random.default_rng(1)
+    few = make_results(
+        pv_ids=range(4), horizon_hour=0, rows_per_site=10, rng=rng, error_scale=0.3
     )
-
-    pv_metadata = pd.DataFrame(
-        columns=[
-            "pv_id",
-            "capacity",
-        ],
-        data=np.random.random((100, 2)),
+    many = make_results(
+        pv_ids=range(100, 140), horizon_hour=1, rows_per_site=10, rng=rng, error_scale=0.3
     )
+    results_df = pd.concat([few, many], ignore_index=True)
+    out = metrics(results_df, make_metadata(results_df)).set_index("horizon_group")
 
-    # call the metrics function
-    metrics(results_df, pv_metadata)
+    width_few = out.loc["0-0", "mae_ci_high"] - out.loc["0-0", "mae_ci_low"]
+    width_many = out.loc["1-1", "mae_ci_high"] - out.loc["1-1", "mae_ci_low"]
+    assert width_few > width_many
+    assert out.loc["0-0", "n"] == 4 * 10
+    assert out.loc["1-1", "n"] == 40 * 10
+
+
+def test_bootstrap_ci_brackets_the_mae_and_is_deterministic():
+    rng = np.random.default_rng(2)
+    error_df = pd.DataFrame(
+        {
+            "pv_id": np.repeat(np.arange(20), 15),
+            "abs_error": np.abs(rng.normal(0.3, 0.15, size=300)),
+        }
+    )
+    low, high = bootstrap_mae_ci(error_df)
+    assert low < error_df["abs_error"].mean() < high
+    # seeded resampling: identical call gives identical interval
+    assert (low, high) == bootstrap_mae_ci(error_df)
+
+
+def test_single_site_gives_nan_interval():
+    error_df = pd.DataFrame({"pv_id": [1] * 10, "abs_error": np.linspace(0, 1, 10)})
+    low, high = bootstrap_mae_ci(error_df)
+    assert np.isnan(low) and np.isnan(high)
+
+
+def test_night_rows_are_filtered_by_default():
+    rng = np.random.default_rng(3)
+    results_df = make_results(pv_ids=range(3), horizon_hour=1, rows_per_site=5, rng=rng, error=0.1)
+    results_df["generation_power"] = 0.05  # night-level output everywhere
+    out = metrics(results_df, make_metadata(results_df))
+    assert len(out) == 0


### PR DESCRIPTION
## What

The per-horizon MAE in `eval/metrics.py` is printed with a `±1.96·SEM` band whose SEM divides by a hardcoded `sqrt(50)`, regardless of how many rows the horizon group actually contains:

```python
sem = np.round((... .abs().std() / 50**0.5), 3)
```

Group sizes vary from a single horizon hour to the `[0, 36]` aggregate, so the reported interval is wrong for essentially every group — too narrow for small groups, too wide for large ones.

## Change

- **Site-resampled percentile bootstrap** replaces the SEM band. Errors from the same PV site share weather and hardware, so the independent unit is the site, not the row — a row-level SEM (even with the right n) would overstate the effective sample size. Pure numpy/pandas, seeded by default so printed intervals are reproducible.
- **`metrics()` now returns the per-horizon table** (`horizon_group, n, mae, mae_ci_low, mae_ci_high, mae_normalized`) instead of only printing. Prints remain, so existing usage is unchanged; the `TODO add more metrics using ocf_ml_metrics` comment goes away (that repo no longer exists).
- **Real tests**: the previous test called `metrics()` on random data and asserted nothing. The new ones pin the MAE on a constructed known error, check the interval brackets the MAE, check it *narrows with more sites* (the regression the hardcoded 50 hid), check determinism under the default seed, and keep the night-filter behavior covered.

Complementary to #361 — that asks for more point metrics (RMSE/MBE); this puts an honest uncertainty on the ones already reported. Happy to follow up with a persistence skill-score baseline (the truth is already fetched for every horizon 0–48h, so it's computable straight from `results_df`) if there's interest.

Verification note: the metric suite runs green locally (5/5); I have not run the full `run_eval` pipeline (needs HF dataset access).
