### PR TITLE
DOC: fix README install step to use editable install from pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,9 @@ To set up the development environment for this project, follow these steps:
   source venv/bin/activate  # On Windows use `venv\Scripts\activate`
   ```
 
-3. **Install the required dependencies:**
+3. **Install the package in editable mode (uses `pyproject.toml`):**
   ```bash
-  pip install -r requirements.txt
+  pip install -e .
   ```
 
 4. **Run the Jupyter Notebook server:**


### PR DESCRIPTION
## Description

Fixes #365.

The `Development Environment Setup` section of `README.md` still asks new contributors to run `pip install -r requirements.txt`, but the repository does not contain a `requirements.txt` file at the project root. The project's actual dependency declaration lives in `pyproject.toml` (`[project.dependencies]`), which is the standard, supported way to install it.

This PR changes step 3 of the setup instructions to use the canonical editable install from `pyproject.toml`, which both works and matches how the project is configured:

```diff
-3. **Install the required dependencies:**
+3. **Install the package in editable mode (uses `pyproject.toml`):**
   ```bash
-  pip install -r requirements.txt
+  pip install -e .
   ```
```

## Checklist
- [x] Pull request is written in English
- [x] Added a brief description of the change (this PR body)
- [x] No new files added; documentation-only change
