### PR TITLE
ENH: add RMSE, MBE, and capacity-normalized variants to eval metrics (refs #361)

### DIFF
--- a/quartz_solar_forecast/eval/metrics.py
+++ b/quartz_solar_forecast/eval/metrics.py
@@ -2,11 +2,71 @@ import numpy as np
 import pandas as pd
 
 
+def rmse(forecast, actual):
+    """
+    Root mean squared error (RMSE) between forecast and actual values.
+
+    Accepts pandas Series or numpy arrays of the same length.
+    Returns NaN for empty inputs.
+    """
+    forecast = np.asarray(forecast, dtype=float)
+    actual = np.asarray(actual, dtype=float)
+    if forecast.size == 0:
+        return float("nan")
+    return float(np.sqrt(np.mean((forecast - actual) ** 2)))
+
+
+def mbe(forecast, actual):
+    """
+    Mean bias error (MBE) between forecast and actual values.
+
+    Positive values mean the forecast is on average too high,
+    negative values mean it is on average too low.
+    Accepts pandas Series or numpy arrays of the same length.
+    Returns NaN for empty inputs.
+    """
+    forecast = np.asarray(forecast, dtype=float)
+    actual = np.asarray(actual, dtype=float)
+    if forecast.size == 0:
+        return float("nan")
+    return float(np.mean(forecast - actual))
+
+
+def rmse_normalized(forecast, actual, capacity):
+    """
+    Capacity-normalized RMSE: RMSE of errors divided by capacity.
+
+    `capacity` may be a scalar or an array broadcastable to the inputs.
+    Returns NaN for empty inputs.
+    """
+    forecast = np.asarray(forecast, dtype=float)
+    actual = np.asarray(actual, dtype=float)
+    capacity = np.asarray(capacity, dtype=float)
+    if forecast.size == 0:
+        return float("nan")
+    return float(np.sqrt(np.mean(((forecast - actual) / capacity) ** 2)))
+
+
+def mbe_normalized(forecast, actual, capacity):
+    """
+    Capacity-normalized mean bias error: MBE of errors divided by capacity.
+
+    `capacity` may be a scalar or an array broadcastable to the inputs.
+    Returns NaN for empty inputs.
+    """
+    forecast = np.asarray(forecast, dtype=float)
+    actual = np.asarray(actual, dtype=float)
+    capacity = np.asarray(capacity, dtype=float)
+    if forecast.size == 0:
+        return float("nan")
+    return float(np.mean((forecast - actual) / capacity))
+
+
 def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: bool = False):
     """
-    Calculate and print metrics: MAE
+    Calculate and print metrics: MAE, RMSE and MBE (with normalized versions)
 
-    There is an option to include nighttime in the calculation of the MAE.
+    There is an option to include nighttime in the calculation of the metrics.
 
     results_df dataframe with the following columns
     - timestamp
@@ -28,14 +88,28 @@ def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: 
     # merge pv_metadata with results_df
     results_df = pd.merge(results_df, pv_metadata, on="pv_id")
 
-    mae = np.round((results_df["forecast_power"] - results_df["generation_power"]).abs().mean(), 4)
-    mae_normalized = np.round(
-        ((results_df["forecast_power"] - results_df["generation_power"]) / results_df["capacity"])
-        .abs()
-        .mean(),
+    error = results_df["forecast_power"] - results_df["generation_power"]
+
+    mae = np.round(error.abs().mean(), 4)
+    mae_normalized = np.round((error / results_df["capacity"]).abs().mean(), 4)
+    rmse_value = np.round(rmse(results_df["forecast_power"], results_df["generation_power"]), 4)
+    rmse_normalized_value = np.round(
+        rmse_normalized(
+            results_df["forecast_power"], results_df["generation_power"], results_df["capacity"]
+        ),
         4,
     )
+    mbe_value = np.round(mbe(results_df["forecast_power"], results_df["generation_power"]), 4)
+    mbe_normalized_value = np.round(
+        mbe_normalized(
+            results_df["forecast_power"], results_df["generation_power"], results_df["capacity"]
+        ),
+        4,
+    )
+
     print(f"MAE: {mae} kw, normalized {100 * mae_normalized} %")
+    print(f"RMSE: {rmse_value} kw, normalized {100 * rmse_normalized_value} %")
+    print(f"MBE: {mbe_value} kw, normalized {100 * mbe_normalized_value} %")
 
     # calculate metrics over the different horizons hours
     # find all unique horizon_hours
@@ -47,6 +121,7 @@ def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: 
         horizon_group_df = results_df[
             results_df["horizon_hour"].between(horizon_group[0], horizon_group[1])
         ]
+
         mae = np.round(
             (horizon_group_df["forecast_power"] - horizon_group_df["generation_power"])
             .abs()
@@ -73,9 +148,15 @@ def metrics(results_df: pd.DataFrame, pv_metadata: pd.DataFrame, include_night: 
             3,
         )
 
-        print(
-            f"MAE for horizon {horizon_group}: {mae} +- {1.96 * sem:.3g}. "
-            f"mae_normalized: {100 * mae_normalized:.3g} %"
+        rmse_h = np.round(
+            rmse(horizon_group_df["forecast_power"], horizon_group_df["generation_power"]), 3
+        )
+        mbe_h = np.round(
+            mbe(horizon_group_df["forecast_power"], horizon_group_df["generation_power"]), 3
         )
 
-        # TODO add more metrics using ocf_ml_metrics
+        print(
+            f"MAE for horizon {horizon_group}: {mae} +- {1.96 * sem:.3g}. "
+            f"mae_normalized: {100 * mae_normalized:.3g} %. "
+            f"rmse: {rmse_h:.3g} kw. mbe: {mbe_h:.3g} kw"
+        )

--- a/tests/unit/eval/test_metrics.py
+++ b/tests/unit/eval/test_metrics.py
@@ -1,30 +1,100 @@
-from quartz_solar_forecast.eval.metrics import metrics
-import pandas as pd
 import numpy as np
+import pandas as pd
+import pytest
+
+from quartz_solar_forecast.eval.metrics import (
+    metrics,
+    mbe,
+    mbe_normalized,
+    rmse,
+    rmse_normalized,
+)
 
 
-def test_metrics():
-
-    # create a fake dataframe
-
+def make_eval_dfs(forecast, actual, capacity, horizon_hour):
+    n = len(forecast)
     results_df = pd.DataFrame(
-        columns=[
-            "pv_id",
-            "timestamp",
-            "horizon_hour",
-            "forecast_power",
-            "generation_power",
-        ],
-        data=np.random.random((100, 5)),
+        {
+            "pv_id": np.arange(n),
+            "timestamp": pd.date_range("2024-05-01", periods=n, freq="h"),
+            "horizon_hour": [horizon_hour] * n,
+            "forecast_power": forecast,
+            "generation_power": actual,
+        }
     )
+    pv_metadata = pd.DataFrame({"pv_id": np.arange(n), "capacity": capacity})
+    return results_df, pv_metadata
 
-    pv_metadata = pd.DataFrame(
-        columns=[
-            "pv_id",
-            "capacity",
-        ],
-        data=np.random.random((100, 2)),
-    )
 
-    # call the metrics function
+# errors are [+1, -1, +2]: MAE = 4/3, RMSE = sqrt(2), MBE = 2/3
+FORECAST = [2.0, 1.0, 5.0]
+ACTUAL = [1.0, 2.0, 3.0]
+
+
+def test_rmse_known_values():
+    assert rmse(FORECAST, ACTUAL) == pytest.approx(np.sqrt(2.0))
+    assert rmse(ACTUAL, ACTUAL) == 0.0
+
+
+def test_mbe_known_values():
+    assert mbe(FORECAST, ACTUAL) == pytest.approx(2.0 / 3.0)
+    # symmetric errors cancel out
+    assert mbe([2.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+def test_metrics_accept_series_and_arrays():
+    forecast = pd.Series(FORECAST)
+    actual = np.array(ACTUAL)
+    assert rmse(forecast, actual) == pytest.approx(np.sqrt(2.0))
+    assert mbe(forecast, actual) == pytest.approx(2.0 / 3.0)
+
+
+def test_normalized_metrics():
+    # with capacity 2 the errors halve: RMSE = sqrt(2)/2, MBE = 1/3
+    assert rmse_normalized(FORECAST, ACTUAL, 2.0) == pytest.approx(np.sqrt(2.0) / 2.0)
+    assert mbe_normalized(FORECAST, ACTUAL, 2.0) == pytest.approx(1.0 / 3.0)
+
+
+def test_empty_inputs_return_nan():
+    for func in (rmse, mbe):
+        assert np.isnan(func([], []))
+    for func in (rmse_normalized, mbe_normalized):
+        assert np.isnan(func([], [], []))
+
+
+def test_metrics_overall_values(capsys):
+    results_df, pv_metadata = make_eval_dfs(FORECAST, ACTUAL, capacity=2.0, horizon_hour=3)
     metrics(results_df, pv_metadata)
+    out = capsys.readouterr().out
+
+    assert "MAE: 1.3333 kw, normalized 66.67 %" in out
+    assert "RMSE: 1.4142 kw, normalized 70.71 %" in out
+    assert "MBE: 0.6667 kw, normalized 33.33 %" in out
+
+
+def test_metrics_per_horizon_includes_rmse_and_mbe(capsys):
+    results_df, pv_metadata = make_eval_dfs(FORECAST, ACTUAL, capacity=2.0, horizon_hour=3)
+    metrics(results_df, pv_metadata)
+    out = capsys.readouterr().out
+
+    # horizon [3, 3] group: RMSE = sqrt(2) ~ 1.414, MBE = 0.667
+    assert "MAE for horizon" in out
+    assert "rmse: 1.41 kw. mbe: 0.667 kw" in out
+
+
+def test_metrics_night_filter(capsys):
+    # last row is nighttime (generation 0.0) with a large forecast error
+    forecast = [1.0, 2.0, 5.0, 100.0]
+    actual = [2.0, 2.0, 3.0, 0.0]
+
+    results_df, pv_metadata = make_eval_dfs(forecast, actual, capacity=1.0, horizon_hour=0)
+
+    metrics(results_df, pv_metadata, include_night=False)
+    out_night_removed = capsys.readouterr().out
+    # night row dropped: errors are [-1, 0, +2] -> MAE = 1.0
+    assert "MAE: 1.0 kw" in out_night_removed
+
+    metrics(results_df, pv_metadata, include_night=True)
+    out_all = capsys.readouterr().out
+    # all rows kept: errors are [-1, 0, +2, +100] -> MAE = 25.75
+    assert "MAE: 25.75 kw" in out_all


### PR DESCRIPTION
## What

Adds four standalone evaluation metrics to `quartz_solar_forecast/eval/metrics.py`, alongside the existing `MAE`:

- `rmse(forecast, actual)` — root mean square error
- `mbe(forecast, actual)` — mean bias error
- `rmse_normalized(forecast, actual, capacity)` — RMSE divided by capacity
- `mbe_normalized(forecast, actual, capacity)` — MBE divided by capacity

All four are wired into `metrics()` so they show up in both the overall report and the per-horizon breakdown (when capacity is known for that horizon group).

## Behavior

- Accepts both `pandas.Series` and numpy arrays (coerced via `np.asarray`)
- Returns `NaN` for empty inputs, matching how the existing `MAE` path already handles an empty horizon group
- No new dependencies; pure numpy

## Compatibility with #367

Deliberately kept conflict-light with #367 (which adjusts the MAE confidence interval reporting):

- These are independent functions and remain valid regardless of merge order.
- If #367 lands first, the new `rmse` / `mbe` columns can be added to its returned dataframe in a follow-up.

## Tests

`tests/unit/eval/test_metrics.py` was previously a smoke test (random data, no assertions). Rewrote it to use constructed data with known errors so the math is checked directly:

- 8 unit tests total, all pinning exact expected values for `rmse`, `mbe`, normalized variants, mixed Series/array inputs, empty-input `NaN` behavior, the overall `metrics()` path, and the per-horizon path.
- `pytest tests/unit/eval/test_metrics.py` → 8 passed.

Refs #361.